### PR TITLE
make sure button cleanup handles lack of button

### DIFF
--- a/mapper/mapper-canvas/mapper-canvas.js
+++ b/mapper/mapper-canvas/mapper-canvas.js
@@ -128,7 +128,9 @@ export const MapperCanvasVM = DefineMap.extend('MapperCanvasVM', {
       const isSpecialButton = button && this.isSpecialButton(button)
 
       // clean up legacy  GIs having `null` targets in button.next
-      button.next = button.next == null ? constants.qIDNOWHERE : button.next
+      if (button && button.next == null) {
+        button.next = constants.qIDNOWHERE
+      }
       const hasNowhereTarget = button && button.next === constants.qIDNOWHERE
 
       // cleanup links for removed buttons, special target buttons, and empty string targets ''

--- a/src/A2J_Pages.js
+++ b/src/A2J_Pages.js
@@ -325,7 +325,7 @@ var debouncedSetQDEmaxHeight = debounce(function () {
 
 var handleNullButtonTargets = function (buttons) {
   for (button of buttons) {
-    if (button.next == null) {
+    if (button && button.next == null) {
       button.next = window.CONST.qIDNOWHERE
     }
   }

--- a/src/a2j-pages-test.js
+++ b/src/a2j-pages-test.js
@@ -39,19 +39,25 @@ describe('src/A2J_Pages', function () {
   })
 
   it('handleNullButtonTargets', function () {
-    const buttons = [
+    let buttons = [
       {label: 'Continue', next: '1-Question'},
       {label: 'Continue', next: null},
       {label: 'Continue', next: undefined}
     ]
-    const expectedButtons = [
+    let expectedButtons = [
       {label: 'Continue', next: '1-Question'},
       {label: 'Continue', next: ''},
       {label: 'Continue', next: ''}
     ]
+    let updatedButtons = window.handleNullButtonTargets(buttons)
 
-      const updatedButtons = window.handleNullButtonTargets(buttons)
-      assert.deepEqual(expectedButtons, updatedButtons, 'should replace button.next targets of `null` or `undefined` with empty string')
+    assert.deepEqual(expectedButtons, updatedButtons, 'should replace button.next targets of `null` or `undefined` with empty string')
+
+    buttons = []
+    expectedButtons = []
+    updatedButtons = window.handleNullButtonTargets(buttons)
+
+    assert.deepEqual(expectedButtons, updatedButtons, 'should do nothing if button does not exist')
   })
 
   it('buildPopupFieldSet', function () {


### PR DESCRIPTION
Add new page in mapper was causing issue with button cleanup when there were no buttons. This fixes that code and updates the test.

closes #40 