### PR TITLE
Guide page edit form test

### DIFF
--- a/src/a2j-pages-test.js
+++ b/src/a2j-pages-test.js
@@ -195,9 +195,9 @@ describe('src/A2J_Pages', function () {
     window.gGuideID = undefined
   })
 
-  it.skip('guidePageEditForm', function () {
+  it('guidePageEditForm', function () {
     // TODO: this test is failing on Travis due to too many dependencies on A2J_Tabs.js
-    // need refactor to break up that coupling/cascade of function calls during tests
+    // need refactor to break up that coupling/cascade
     // this prevents an error trying to upload the fake mp3 file below
     window.gGuideID = 0
     var $qdeParentDiv = window.$('<div></div>')
@@ -219,10 +219,16 @@ describe('src/A2J_Pages', function () {
       fields: [field]
     }
 
+    // overload some coupled functions for Travis tests
+    window.form.listManager.save = function () { return page.fields }
+    window.form.tableRowAdjust = function () { return }
+    window.lang.scriptErrorUnhandled = { printf: function () { return } }
+
     const $guidePageEditForm = window.guidePageEditForm(page, $qdeParentDiv)
     const fieldSets = $guidePageEditForm.find('fieldset')
     assert.equal(fieldSets.length, 6, 'should create 6 QDE fieldsets: Page, Question, Learn More, Fields, Buttons, Logic')
 
+    // cleanup
     window.gGuideID = undefined
   })
 })


### PR DESCRIPTION
This fixes the failing test on Travis CI due to the legacy code coupling across many global function calls.