### PR TITLE
remove modal class from page picker dialog

### DIFF
--- a/src/A2J_Tabs.js
+++ b/src/A2J_Tabs.js
@@ -402,7 +402,7 @@ window.form = {
         // $('page-picker-dialog').dialog( "close" );
       })
     $('#page-picker-dialog').data(data).dialog({
-      dialogClass: 'modal ',
+      dialogClass: '',
       autoOpen: true,
       width: 700,
       height: 500,
@@ -466,7 +466,7 @@ window.form = {
       })
 
     $('#page-picker-dialog').data(data).dialog({
-  		dialogClass: 'modal ',
+  		dialogClass: '',
       autoOpen: true,
       width: 700,
       height: 500,


### PR DESCRIPTION
The previous 'bootstrap-styles' wrapper class was disabling the jquery-ui assigned 'modal' class to the page-picker dialog. Removing that wrapper restored those class styles, ironically messing up the modal. This removes that `dialogClass` setting, restore the customs styles.

closes #48 