### PR TITLE
fix help links, including map page

### DIFF
--- a/app.stache
+++ b/app.stache
@@ -137,7 +137,7 @@
 
     <!-- Maps Tab -->
     <div class="tab-panel" id="tabsMap">
-      {{#is (page, "mapper")}}
+      {{#is (page, "map")}}
         <mapper-page guide:from="guide" />
       {{/is}}
     </div>

--- a/src/utils/help-page-url.js
+++ b/src/utils/help-page-url.js
@@ -9,7 +9,7 @@
  * the a2j author help page.
  *
  */
-const basePath = 'http://author.a2jauthor.org/content/'
+const basePath = 'https://www.a2jauthor.org/content/'
 
 const pageToHelpUrlMap = {
   about: 'chapter-4-about-tab',

--- a/src/vertical-navbar/navbar-items.js
+++ b/src/vertical-navbar/navbar-items.js
@@ -28,7 +28,7 @@ export default [
     active: false
   },
   {
-    page: 'mapper',
+    page: 'map',
     title: 'Map',
     ref: 'tabsMap',
     icon: 'glyphicon-sitemap',


### PR DESCRIPTION
This fixes the base url for the Help links, including the Map tab. some of those help links are outdated @JessicaFrank as I'm sure you know. You're welcome ❤️ 

closes #52 