### PR TITLE
66 allow only letters numbers and digits in alt-text

### DIFF
--- a/legacy/A2J_Pages.js
+++ b/legacy/A2J_Pages.js
@@ -575,6 +575,13 @@ function buildQuestionFieldSet (page) {
   return questionFieldSet
 }
 
+var helpAltTextChangeHandler = function (val, page) {
+  val = val.replace(/[^\w\s]|_/g, "") // only allow letters, digits, and whitespace
+          .replace(/\s+/g, " ") // single spaces only
+  page.helpAltText = window.$.trim(val).substring(0, 120)
+  return val
+}
+
 /** @param {TPage} page */
 function buildLearnMoreFieldSet (page) {
   var learnMoreFieldSet = window.form.fieldset('Learn More Info', page)
@@ -619,9 +626,9 @@ function buildLearnMoreFieldSet (page) {
   learnMoreFieldSet.append(window.form.text({
     name: 'helpAltText',
     label: 'Graphic Alt-Text:',
-    placeholder: 'Enter 100 characters or less to describe your image for Aria readers. Hint: 100 characters ends here',
+    placeholder: 'Enter 100 characters or less (no punctuation) to describe your image for Aria readers. Hint: 100 characters ends here',
     value: page.helpAltText,
-    change: function (val, page) { page.helpAltText = window.$.trim(val).substring(0, 120) }
+    change: helpAltTextChangeHandler
   }))
 
   learnMoreFieldSet.append(window.form.pickVideo({

--- a/legacy/a2j-pages-test.js
+++ b/legacy/a2j-pages-test.js
@@ -134,6 +134,15 @@ describe('legacy/A2J_Pages', function () {
     window.gGuideID = undefined
   })
 
+  it('helpAltText change handler', function () {
+    const mockPage = { helpAltText: '' }
+    const dirtyAltText = 'Too much $%^ punctuation!! and     "whitespace" for 1'
+    const result = window.helpAltTextChangeHandler(dirtyAltText, mockPage)
+    const expectedResult = 'Too much punctuation and whitespace for 1'
+
+    assert.equal(result, expectedResult, 'should clear all unsafe characters leaving only letters, digits, and single whitespace')
+  })
+
   it('buildFieldsFieldSet', function () {
     // this prevents an error trying to upload the fake mp3 file below
     window.gGuideID = 0


### PR DESCRIPTION
This updates the placeholder message to say `no punctuation` but also strips out any special characters before saving. It will allow only letters, digits, and whitespace.  Extra spaces are also reduced down to one space, so:

`Some !"thing" is > another 1` will become `Some thing is another 1`

closes #66