### PR TITLE
61 update start/exit target on page rename

### DIFF
--- a/legacy/A2J_Pages.js
+++ b/legacy/A2J_Pages.js
@@ -1068,5 +1068,23 @@ window.TGuide.prototype.pageFindReferences = function (findName, newName) {
       }
     }
   }
+  // test firstPage and exitPage values and update
+  if (guide.firstPage === findName) {
+    if (newName != null) {
+      guide.firstPage = newName
+      // span does not refresh, update it
+      $('.starting').find('span').text(newName)
+    }
+    matches.push({ name: 'Steps Tab', field: 'Starting Point', text: guide.firstPage })
+  }
+  if (guide.exitPage === findName) {
+    if (newName != null) {
+      guide.exitPage = newName
+      // span does not refresh, update it
+      $('.starting').find('span').text(newName)
+    }
+    matches.push({ name: 'Steps Tab', field: 'Exit Point', text: guide.exitPage })
+  }
+
   return matches
 }

--- a/legacy/a2j-pages-test.js
+++ b/legacy/a2j-pages-test.js
@@ -29,13 +29,20 @@ describe('legacy/A2J_Pages', function () {
   })
 
   it('pageFindReferences', function () {
+    window.gGuide.firstPage = 'page2'
+    window.gGuide.exitPage = 'page2'
+
     const matches = window.gGuide.pageFindReferences('page2', null)
-    assert.equal(matches.length, 1, 'should find references in button.next targets')
+    assert.equal(matches.length, 3, 'should find references in button.next targets and start/exit pages')
     assert.equal(matches[0].next, 'page2', 'should not rename next target if newName not passed')
+    assert.equal(matches[1].text, 'page2', 'should not rename starting page target if newName not passed')
+    assert.equal(matches[2].text, 'page2', 'should not rename exit page target if newName not passed')
 
     const renameMatches = window.gGuide.pageFindReferences('page2', 'lasercats')
-    assert.equal(renameMatches.length, 1, 'should find references in button.next targets')
+    assert.equal(renameMatches.length, 3, 'should find references in button.next targets and start/exit pages')
     assert.equal(renameMatches[0].next, 'lasercats', 'should rename next target if newName is passed')
+    assert.equal(renameMatches[1].text, 'lasercats', 'should rename starting target if newName is passed')
+    assert.equal(renameMatches[2].text, 'lasercats', 'should rename exit target if newName is passed')
   })
 
   it('handleNullButtonTargets', function () {


### PR DESCRIPTION
This update start/exit pages with the correct target when an Author changes a page name that was already set as a target for start/exit. It also adds them to the usage list when an Author deletes a page.

closes #61 