### PR TITLE
35 call debouncedGuideSave after new pages/popups

### DIFF
--- a/legacy/A2J_AuthorApp.js
+++ b/legacy/A2J_AuthorApp.js
@@ -363,9 +363,13 @@ function main () { // Everything loaded, now execute code.
 
   $('#tabsPages #new-page').click(function () {
     createNewPage()
+    // debouncedGuideSave defined in A2J_Guides.js
+    window.debouncedGuideSave()
   })
   $('#tabsPages #new-popup').click(function () {
     createNewPopup()
+    // debouncedGuideSave defined in A2J_Guides.js
+    window.debouncedGuideSave()
   })
 
   $('#vars_load').button({label: 'Load', icons: {primary: 'ui-icon-locked'}}).next().button({label: 'Save', icons: {primary: 'ui-icon-locked'}})

--- a/legacy/A2J_Guides.js
+++ b/legacy/A2J_Guides.js
@@ -115,6 +115,9 @@ window.guideSave = function guideSave (onFinished) {
   }
 }
 
+// used for new page and new popup to allow mutiple new pages with single save
+var debouncedGuideSave =   window.debounce(window.guideSave, 1000, false)
+
 function loadNewGuidePrep () {
   $('.pageoutline').html('')
 }

--- a/legacy/A2J_Pages.js
+++ b/legacy/A2J_Pages.js
@@ -307,7 +307,9 @@ function debounce (func, wait, immediate) {
 
     timeout = setTimeout(later, wait)
 
-    if (callNow) func.apply(context, args)
+    if (callNow) { // call on leading edge
+      func.apply(context, args)
+    }
   }
 }
 // update maxHeight on resize
@@ -319,9 +321,7 @@ function setQDEmaxHeight () {
 }
 
 // debounced version
-var debouncedSetQDEmaxHeight = debounce(function () {
-  setQDEmaxHeight()
-}, 150)
+var debouncedSetQDEmaxHeight = debounce(setQDEmaxHeight, 150, false)
 
 var handleNullButtonTargets = function (buttons) {
   for (button of buttons) {


### PR DESCRIPTION
This adds a debounce call after new pages/popups are created in the Pages Tab. It will save after a second has passed, so quickly adding pages will only call one save event.

closes #35 