### PR TITLE
debounce sortAndSave() instead of  guideSave()

### DIFF
--- a/legacy/A2J_AuthorApp.js
+++ b/legacy/A2J_AuthorApp.js
@@ -364,13 +364,9 @@ function main () { // Everything loaded, now execute code.
 
   $('#tabsPages #new-page').click(function () {
     createNewPage()
-    // debouncedGuideSave defined in A2J_Guides.js
-    window.debouncedGuideSave()
   })
   $('#tabsPages #new-popup').click(function () {
     createNewPopup()
-    // debouncedGuideSave defined in A2J_Guides.js
-    window.debouncedGuideSave()
   })
 
   $('#vars_load').button({label: 'Load', icons: {primary: 'ui-icon-locked'}}).next().button({label: 'Save', icons: {primary: 'ui-icon-locked'}})

--- a/legacy/A2J_Guides.js
+++ b/legacy/A2J_Guides.js
@@ -115,9 +115,6 @@ window.guideSave = function guideSave (onFinished) {
   }
 }
 
-// used for new page and new popup to allow mutiple new pages with single save
-var debouncedGuideSave =   window.debounce(window.guideSave, 1000, false)
-
 function loadNewGuidePrep () {
   $('.pageoutline').html('')
 }

--- a/src/mapper/mapper-canvas/jointjs-util.js
+++ b/src/mapper/mapper-canvas/jointjs-util.js
@@ -239,10 +239,8 @@ const handleGraphEvents = (graph, vm) => {
     // event listener in bind-custom-events.js updates the CanJS guide model
     gGuidePage.mapx = position.x
     gGuidePage.mapy = position.y
-    // debounce for autoCleanup() call from toolbar
-    window.debouncedGuideSave()
 
-    // This dispatched event is debounced/handled in MapperCanvasVM
+    // This dispatched event is debounced/handled in MapperCanvasVM which triggers a save
     vm.dispatch('node-position-update')
   })
 }

--- a/src/mapper/mapper-canvas/mapper-canvas.js
+++ b/src/mapper/mapper-canvas/mapper-canvas.js
@@ -326,7 +326,7 @@ export const MapperCanvasVM = DefineMap.extend('MapperCanvasVM', {
     const vm = this
 
     // TODO - watch for circular events in jointjs-util.js, good currently
-    vm.listenTo('node-position-update', _debounce(this.sortAndSaveGuidePages, 30))
+    vm.listenTo('node-position-update', _debounce(this.sortAndSaveGuidePages, 300, false))
 
     vm.listenTo('selectedNodeView', function () {
       if (vm.selectedNodeView) {


### PR DESCRIPTION
This moves the debounce from guideSave() to the mapper sortAndSave() function, which prevents over saving, but still saving quick changes like a single node drag movement.