### PR TITLE
114 use steal-sans-promises in production build

### DIFF
--- a/build.production.html.js
+++ b/build.production.html.js
@@ -44,7 +44,7 @@ function template (version) {
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=${version}" cache-key="v" cache-version="${version}" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal-sans-promises.production.js?v=${version}" cache-key="v" cache-version="${version}" main="a2jauthor/app"></script>
     </body>
   </html>`
 }


### PR DESCRIPTION
matches dev environment. Can likely use promise version after upgrade to stealjs 2.x

close #114