### PR TITLE
124 refresh files on nav to All Files tab

### DIFF
--- a/src/utils/tabs-routing.js
+++ b/src/utils/tabs-routing.js
@@ -19,6 +19,11 @@ export default function tabsRouting (appState) {
       appState.action = undefined
     }
 
+    // TODO: remove this side effect when All Files refactored to CanJS
+    if (newPage === 'files' && window.gGuide) {
+      window.updateAttachmentFiles()
+    }
+
     let item = navbarItems.filter(item => item.page === newPage).shift()
     if (item && item.ref) {
       window.gotoTabOrPage(item.ref)


### PR DESCRIPTION
This uses current legacy global `updateAttachmentFiles()` when clicking the All Files tab to make sure newly created templates are rendered. It's a side effect in a routing hack that should be removed when the All Files tab is refactored to CanJS (stache will auto refresh the files list)

closes #124 