### PR TITLE
Revert "126 save the gGuide before mapper-canvas init"

### DIFF
--- a/src/mapper/mapper-canvas/mapper-canvas.js
+++ b/src/mapper/mapper-canvas/mapper-canvas.js
@@ -278,20 +278,6 @@ export const MapperCanvasVM = DefineMap.extend('MapperCanvasVM', {
     window.guideSave()
   },
 
-  saveCurrentGuidePromise: {
-    get () {
-      // this assures any changes to current guide are saved before loading
-      // the mapper canvas TODO: remove when legacy code refactored to CanJS
-      return new Promise(function (resolve, reject) {
-        if (window.gGuide) {
-          window.guideSave(resolve)
-        } else {
-          resolve()
-        }
-      })
-    }
-  },
-
   initMapper (paper) {
     const vm = this
     const graph = paper.options.model
@@ -364,10 +350,7 @@ export const MapperCanvasVM = DefineMap.extend('MapperCanvasVM', {
 
     // mutateQueue let's the dom update with the spinner while the expensive work
     // of adding the mapper nodes can happen after
-    // save the guide first
-    this.saveCurrentGuidePromise.then(() => {
-      queues.mutateQueue.enqueue(vm.initMapper, vm, [ vm.paper ])
-    })
+    queues.mutateQueue.enqueue(vm.initMapper, vm, [ vm.paper ])
 
     // cleanup event listeners
     return () => {


### PR DESCRIPTION
Reverts CCALI/a2jauthor#131

This caused the loading spinner to sometimes never be removed. Did some exploration for a better solution, but will take more time/tech debt refactoring.