### PR TITLE
139 create popup

### DIFF
--- a/src/utils/ckeditor-area.js
+++ b/src/utils/ckeditor-area.js
@@ -33,6 +33,13 @@ export default function ckeArea (data) { // change handler function, label, valu
   const replaceWithCKEditor = function (ev) {
     // do not re initialize the current instance
     if (window.CKEDITOR.instances[id]) { return }
+    // remove previous instance(s)
+    Object.keys(window.CKEDITOR.instances).forEach(function (instanceKey) {
+      if (instanceKey !== id) {
+        // `true` says to not update original element (blur event already did it)
+        window.CKEDITOR.instances[instanceKey].destroy(true)
+      }
+    })
     // add the CKEditor
     window.CKEDITOR.replace(document.getElementById(id), {
       // do not escape html entities, except special characters for xml compatibility

--- a/src/utils/ckeditor-area.js
+++ b/src/utils/ckeditor-area.js
@@ -74,9 +74,10 @@ export default function ckeArea (data) { // change handler function, label, valu
       ],
       on: {
         blur: function (event) {
-          // destroy triggers update to original div
-          const instanceName = event.editor.name
-          window.CKEDITOR.instances[instanceName].destroy(true)
+          // Update the data when the element is blured
+          var d = event.editor.getData()
+          // change function sometimes requires field prop
+          data.change(d, data.field)
         },
         change: function (event) {
           // Update the data when data changes


### PR DESCRIPTION
ckeAreas were destroying themselves on `blur` which worked fine for most text editing, but adding a Popup page also blurs by opening a modal, which prevented the generated popup link from being saved back into the original html. Restored data update on blur, and added the cleanup of previous ckeditor instances at the beginning of replacing the current element with a new ckeArea instance.

closes #139