### PR TITLE
Remove the Marker option from the Styles dropdown

### DIFF
--- a/ckeditor/styles.js
+++ b/ckeditor/styles.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
@@ -58,8 +58,6 @@ CKEDITOR.stylesSet.add( 'default', [
 	{ name: 'Subscript',		element: 'sub' },
 	{ name: 'Superscript',		element: 'sup' },
 	*/
-
-	{ name: 'Marker',			element: 'span', attributes: { 'class': 'marker' } },
 
 	{ name: 'Big',				element: 'big' },
 	{ name: 'Small',			element: 'small' },


### PR DESCRIPTION
Before:

<img width="163" alt="Marker option is available" src="https://user-images.githubusercontent.com/10070176/146318477-772acbb9-c293-4fe3-9194-0ac7517aaa24.png">

After:

<img width="165" alt="Marker option is removed" src="https://user-images.githubusercontent.com/10070176/146318494-980df92f-ff3d-47b4-88b4-03c1fcc45451.png">

I’d appreciate any suggestions on how best to add tests for this.

Part of https://github.com/CCALI/a2jauthor/issues/232