### PR TITLE
launch qa jun 2022

### DIFF
--- a/legacy/viewer/A2J_SharedSus.js
+++ b/legacy/viewer/A2J_SharedSus.js
@@ -12,7 +12,7 @@ var REG = {
   LOGIC_SET: /set\s+(.+)/i,
   LOGIC_SETTO: /set\s+([\w#]+|\[.+\])\s*?\s(=|TO)\s+?(.+)/i,
   LOGIC_GOTO: /^goto\s+\"(.+)\"/i,
-  LOGIC_GOTO2: /^goto\s+(.+)/i,
+  LOGIC_GOTO2: /^\s*goto\s+(.+)/i,
   LOGIC_TRACE: /trace\s+(.+)/i,
   LOGIC_WRITE: /write\s+(.+)/i,
   LOGIC_ELSEIF: /^else if\s+(.+)/i,

--- a/src/merge-tool/merge-tool.less
+++ b/src/merge-tool/merge-tool.less
@@ -7,6 +7,19 @@ merge-tool {
     display: none;
   }
 
+  .merge-guides-top {
+    margin-left: 10px;
+    margin-bottom: 5px;
+    display: inline-block;
+    cursor: pointer;
+  }
+  .sample-guides-merge {
+    margin-bottom: 10px;
+    a {
+      cursor: pointer;
+    }
+  }
+
   .form-control-clear {
     position: absolute;
     height: 100%;

--- a/src/merge-tool/merge-tool.stache
+++ b/src/merge-tool/merge-tool.stache
@@ -4,7 +4,7 @@
 
 {{<interviewList}}
   <div class="source-list list-group">
-  <a class="merge-guides-top" on:click="scrollTo('.sample-guides-merge')">[go to sample A2J Guided Interviews®]</a>
+    <a class="merge-guides-top" on:click="scrollTo('.sample-guides-merge')" tabindex="0">[go to sample A2J Guided Interviews®]</a>
     <form class="navbar-form" role="search">
       <div class="input-group" style="width: 100%;">
         <input type="text"
@@ -23,22 +23,24 @@
     </form>
     {{let list=filterGuideList(./listOfGuides, getSearchFilter(./searchFilter))}}
     {{#for(guide of list)}}
-      <a class="list-group-item" on:click="mtg.load(guide.id)">
+      <a class="list-group-item" on:click="mtg.load(guide.id)" tabindex="0">
         <span class="title">{{guide.title}}</span><br>
-        <small class="text-muted">#{{guide.id}} | {{formatFileSize guide.fileSize}} | {{guide.lastModified}} 
-        {{^if guide.owned}}
-         | sample
-        {{/if}}</small>
+        <small class="text-muted">
+          #{{guide.id}} | {{formatFileSize guide.fileSize}} | {{guide.lastModified}} {{#if(../isSample(guide))}}| sample {{/if}}
+        </small>
       </a>
     {{/for}}
     <hr>
-    <a id="samples" class="sample-guides-merge">Sample A2J Guided Interviews®</a>
-    <a on:click="scrollTo('.merge-guides-top')">[back to top]</a>
+    <div id="samples" class="sample-guides-merge">
+      Sample A2J Guided Interviews® <a on:click="scrollTo('.merge-guides-top')" tabindex="0">[back to top]</a>
+    </div>
     {{let samplelist=samples(./listOfGuides)}}
     {{#for(guide of samplelist)}}
-      <a class="list-group-item" on:click="mtg.load(guide.id)">
+      <a class="list-group-item" on:click="mtg.load(guide.id)" tabindex="0">
         <span class="title">{{guide.title}}</span><br>
-        <small class="text-muted">#{{guide.id}} | {{formatFileSize guide.fileSize}} | {{guide.lastModified}}</small>
+        <small class="text-muted">
+          #{{guide.id}} | {{formatFileSize guide.fileSize}} | {{guide.lastModified}} {{#if(../isSample(guide))}}| sample {{/if}}
+        </small>
       </a>
     {{/for}}
   </div>

--- a/src/pages-tab/components/advanced-logic/logic-editor/logic-editor.js
+++ b/src/pages-tab/components/advanced-logic/logic-editor/logic-editor.js
@@ -147,7 +147,7 @@ export const LogicEditorVM = DefineMap.extend('LogicEditorVM', {
   },
 
   get gotoActive () {
-    return this.unescapedActiveLine.toLowerCase().indexOf('goto') === 0
+    return this.unescapedActiveLine.toLowerCase().trim().indexOf('goto') === 0
   },
 
   get gotoFilterText () {
@@ -158,7 +158,8 @@ export const LogicEditorVM = DefineMap.extend('LogicEditorVM', {
     const node = this.cursorInNode
     if (this.gotoActive && node) {
       if (node.nodeType === 3) { // text node
-        node.data = `GOTO "${newPageName}"`
+        const preserveLeadingSpacesAndCasing = this.unescapedActiveLine.replace(/(^\s*(?:goto)?).*/i, '$1') || 'GOTO'
+        node.data = `${preserveLeadingSpacesAndCasing} "${newPageName}"`
       }
     }
   },
@@ -220,6 +221,7 @@ export const LogicEditorVM = DefineMap.extend('LogicEditorVM', {
     } else if (!(document.activeElement && document.activeElement.hasAttribute('contenteditable'))) {
       // skip updating displayedValue if we re-focused the editor already, as it will blur again when author is done editing
       this.displayedValue = el.innerHTML
+      this.activeLine = '' // clear suggestions since html changed
     }
   },
 

--- a/src/pages-tab/components/file-picker/file-picker.js
+++ b/src/pages-tab/components/file-picker/file-picker.js
@@ -2,6 +2,7 @@ import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
 import template from './file-picker.stache'
 import constants from 'a2jauthor/src/models/constants'
+import { onlyOne } from '../../helpers/helpers'
 
 export const FilePicker = DefineMap.extend('FilePicker', {
   appState: {},
@@ -62,8 +63,19 @@ export const FilePicker = DefineMap.extend('FilePicker', {
   newObservableBool (tf = false) {
     return new DefineMap({ value: tf })
   },
+  onlyOne (observableBool) {
+    if (onlyOne.observableBoolAtATime && observableBool !== onlyOne.observableBoolAtATime) {
+      onlyOne.observableBoolAtATime.value = false
+    }
+    onlyOne.observableBoolAtATime = observableBool
+  },
   toggleBool (observableBool) {
+    this.onlyOne(observableBool)
     observableBool.value = !observableBool.value
+  },
+  makeTrue (observableBool) {
+    this.onlyOne(observableBool)
+    observableBool.value = true
   },
 
   validName (newValue) {
@@ -88,6 +100,10 @@ export const FilePicker = DefineMap.extend('FilePicker', {
           filename && (this.filterText = filename)
         })
     }
+  },
+
+  focusFirstButtonInList (ev) {
+    (ev.keyCode === 40) && ev.target.parentNode.querySelector('ul button').focus() // down arrow key
   }
 })
 
@@ -95,5 +111,18 @@ export default Component.extend({
   tag: 'file-picker',
   view: template,
   leakScope: false,
-  ViewModel: FilePicker
+  ViewModel: FilePicker,
+  events: {
+    'ul button keydown': function (el, ev) {
+      const thisLi = ev.target.parentNode
+      const prevButton = thisLi.previousElementSibling && thisLi.previousElementSibling.querySelector('button')
+      const nextButton = thisLi.nextElementSibling && thisLi.nextElementSibling.querySelector('button')
+      ev.keyCode === 38 && prevButton && prevButton.focus() // up arrow key
+      ev.keyCode === 40 && nextButton && nextButton.focus() // down arrow key
+      if (({ 37: 1, 38: 1, 40: 1 })[ev.keyCode]) { // escape (37)
+        ev.preventDefault()
+        ev.stopPropagation()
+      }
+    }
+  }
 })

--- a/src/pages-tab/components/file-picker/file-picker.stache
+++ b/src/pages-tab/components/file-picker/file-picker.stache
@@ -1,6 +1,6 @@
 <can-import from="./file-picker.less" />
 
-<div class="div">
+<div class="div auto-close-shared-bool-on-outside-focus">
   {{let pickerVisible = newObservableBool(false)}}
   <label class="control-label">{{label}}:</label>
   <div class="has-file-picker">
@@ -13,9 +13,10 @@
       placeholder=""
       type="text"
       autocomplete="off"
-      on:focus="pickerVisible.value = true"
+      on:focus="makeTrue(pickerVisible)"
       value:bind="filterText"
       on:input="filterText = scope.element.value"
+      on:keydown="focusFirstButtonInList(scope.event)"
     >
     <div class="file-picker-toggle">
       <button aria-label="Toggle File Picker" on:click="toggleBool(pickerVisible)" class="glyphicon-list-bullet"></button>

--- a/src/pages-tab/components/page-buttons/page-buttons.js
+++ b/src/pages-tab/components/page-buttons/page-buttons.js
@@ -5,6 +5,7 @@ import Component from 'can-component'
 import template from './page-buttons.stache'
 import { TButton } from '~/legacy/viewer/A2J_Types'
 import constants from 'a2jauthor/src/models/constants'
+import { ObservableProxy } from '../../helpers/helpers'
 
 export const PageButtonsVM = DefineMap.extend('PageButtonsVM', {
   page: {},
@@ -103,20 +104,25 @@ export const PageButtonsVM = DefineMap.extend('PageButtonsVM', {
   // el is the button element itself,
   // button is the page button object,
   // index is which button it is in the buttons list
-  pickPageDialog (el, button, index) {
+  pickPageDialog (el, button, index, buttonNextProxy) {
     const vm = this
     return window.form.pickPageDialog(el, {
       value: button.next,
       label: 'Destination:',
       buttonText: 'Set Destination',
       change: function (val, b, ff) {
-        button.next = val
+        buttonNextProxy.value = val // sets button.next but also lets stache update when it changes
         // ff is jquery wrapped el.closest('tr') and I think the var name means 'fieldset field'? or 'form fieldset'?
         window.updateButtonLayout(ff, button)
         vm.showMessageInputForButton[index] = vm.buttonIsDisplayMessage(button)
         vm.buttonsChanged = vm.buttonsChanged + 1
       }
     })
+  },
+
+  // helps us watch/bind legacy properties that aren't observable
+  newObservableProxy (obj, key) {
+    return new ObservableProxy({ obj, key })
   },
 
   get observableButtons () {

--- a/src/pages-tab/components/page-buttons/page-buttons.stache
+++ b/src/pages-tab/components/page-buttons/page-buttons.stache
@@ -54,17 +54,18 @@
                 <label class="control-label">Default Value:</label>
                 <input class="form-control ui-widget editable" type="text" placeholder="" value:bind="button.value">
               </div>
-              <div class="destination-picker" name="undefined">
+              <div class="button-destination-picker" name="undefined">
+                {{let buttonNextProxy = newObservableProxy(button, 'next')}}
                 <label>Destination:</label>
-                <span>{{button.next}}</span>
+                <span>{{buttonNextProxy.value}}</span>
                 <button
-                  on:click="pickPageDialog(scope.element, button, scope.index)"
+                  on:click="pickPageDialog(scope.element, button, scope.index, buttonNextProxy)"
                   class="btn btn-default ui-button ui-corner-all ui-widget glyphicon-link"
                 >
                   Set Destination
                 </button>
-                {{#if(button.next)}}
-                  <button on:click="scrollTopAndEdit(scope.element, button.next)"
+                {{#if(buttonNextProxy.value)}}
+                  <button on:click="scrollTopAndEdit(scope.element, buttonNextProxy.value)"
                     class="btn btn-default ui-button ui-corner-all ui-widget glyphicon-new-message"
                   >
                     Edit Page

--- a/src/pages-tab/components/page-edit-form/page-edit-form.js
+++ b/src/pages-tab/components/page-edit-form/page-edit-form.js
@@ -14,7 +14,7 @@ export const PageEditFormVM = DefineMap.extend('PageEditFormVM', {
     return page.type === constants.ptPopup
   },
 
-  selectedTab: { default: 'Page Info' },
+  selectedTab: { default: 'Page & Question Info' },
 
   toggleTabs () {
     this.appState.modalTabView = !this.appState.modalTabView

--- a/src/pages-tab/components/page-edit-form/page-edit-form.stache
+++ b/src/pages-tab/components/page-edit-form/page-edit-form.stache
@@ -19,18 +19,18 @@
         Tabbed View
       {{/if}}
     </button>
+    {{let pnqi = 'Page & Question Info'}}
     {{#if(appState.modalTabView)}}
       <div class="page-edit-form-tabs">
-        <button on:click="selectedTab = 'Page Info'" class="{{#is(selectedTab, 'Page Info')}}selected-tab{{/is}}">Page Info</button>
-        <button on:click="selectedTab = 'Question Info'" class="{{#is(selectedTab, 'Question Info')}}selected-tab{{/is}}">Question Info</button>
+        <button on:click="selectedTab = pnqi" class="{{#is(selectedTab, pnqi)}}selected-tab{{/is}}">{{pnqi}}</button>
         <button on:click="selectedTab = 'Learn More Info'" class="{{#is(selectedTab, 'Learn More Info')}}selected-tab{{/is}}">Learn More Info</button>
         <button on:click="selectedTab = 'Fields'" class="{{#is(selectedTab, 'Fields')}}selected-tab{{/is}}">Fields</button>
         <button on:click="selectedTab = 'Buttons'" class="{{#is(selectedTab, 'Buttons')}}selected-tab{{/is}}">Buttons</button>
         <button on:click="selectedTab = 'Advanced Logic'" class="{{#is(selectedTab, 'Advanced Logic')}}selected-tab{{/is}}">Advanced Logic</button>
       </div>
     {{/if}}
-    <page-info class="tab-panel {{#if(appState.modalTabView)}}{{#is(selectedTab, 'Page Info')}}selected-tab-panel{{else}}hidden-tab{{/is}}{{/if}}" page:from="page" appState:from="appState" />
-    <question-info class="tab-panel {{#if(appState.modalTabView)}}{{#is(selectedTab, 'Question Info')}}selected-tab-panel{{else}}hidden-tab{{/is}}{{/if}}" page:from="page" appState:from="appState" guideFiles:from="guideFiles" />
+    <page-info class="tab-panel {{#if(appState.modalTabView)}}{{#is(selectedTab, pnqi)}}selected-tab-panel{{else}}hidden-tab{{/is}}{{/if}}" page:from="page" appState:from="appState" />
+    <question-info class="tab-panel {{#if(appState.modalTabView)}}{{#is(selectedTab, pnqi)}}selected-tab-panel{{else}}hidden-tab{{/is}}{{/if}}" page:from="page" appState:from="appState" guideFiles:from="guideFiles" />
     <learn-more class="tab-panel {{#if(appState.modalTabView)}}{{#is(selectedTab, 'Learn More Info')}}selected-tab-panel{{else}}hidden-tab{{/is}}{{/if}}" page:from="page" appState:from="appState" guideFiles:from="guideFiles" />
     <page-fields class="tab-panel {{#if(appState.modalTabView)}}{{#is(selectedTab, 'Fields')}}selected-tab-panel{{else}}hidden-tab{{/is}}{{/if}}" page:from="page" appState:from="appState" guideFiles:from="guideFiles" />
     <page-buttons

--- a/src/pages-tab/components/var-picker/field/var-picker-field.js
+++ b/src/pages-tab/components/var-picker/field/var-picker-field.js
@@ -2,8 +2,7 @@ import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
 import template from './var-picker-field.stache'
 import { TVariable } from '~/legacy/viewer/A2J_Types'
-
-let onlyOneOpenAtATime
+import { onlyOne } from '../../../helpers/helpers'
 
 export const VarPickerField = DefineMap.extend('VarPickerField', {
   page: {},
@@ -38,10 +37,10 @@ export const VarPickerField = DefineMap.extend('VarPickerField', {
     return new DefineMap({ value: tf })
   },
   onlyOne (observableBool) {
-    if (onlyOneOpenAtATime && observableBool !== onlyOneOpenAtATime) {
-      onlyOneOpenAtATime.value = false
+    if (onlyOne.observableBoolAtATime && observableBool !== onlyOne.observableBoolAtATime) {
+      onlyOne.observableBoolAtATime.value = false
     }
-    onlyOneOpenAtATime = observableBool
+    onlyOne.observableBoolAtATime = observableBool
   },
   toggleBool (observableBool) {
     this.onlyOne(observableBool)
@@ -86,10 +85,17 @@ export const VarPickerField = DefineMap.extend('VarPickerField', {
         this.appState.guide.vars.assign({ [name.toLowerCase()]: v })
         this.filterText = ''
         this.filterText = name
+        if (window.gGuide && window.gGuide.varCreate) {
+          window.gGuide.varCreate(name, v.type, v.repeating, v.comment)
+        }
       }
       bool.value = false
       this.newVarData = undefined
     }
+  },
+
+  focusFirstButtonInList (ev) {
+    (ev.keyCode === 40) && ev.target.parentNode.querySelector('ul button').focus() // down arrow key
   }
 })
 

--- a/src/pages-tab/components/var-picker/field/var-picker-field.stache
+++ b/src/pages-tab/components/var-picker/field/var-picker-field.stache
@@ -3,7 +3,7 @@
 <can-import from='~/src/modal/'/>
 <can-import from="~/src/variables/editor/"/>
 
-<div class="divvariable">
+<div class="divvariable auto-close-shared-bool-on-outside-focus">
   {{let nameVarPickerVisible = newObservableBool(false)}}
   {{let showVariableModal = newObservableBool(false)}}
   <label class="control-label">{{label}}</label>
@@ -20,6 +20,7 @@
       on:focus="makeTrue(nameVarPickerVisible)"
       value:bind="filterText"
       on:input="filterText = scope.element.value"
+      on:keydown="focusFirstButtonInList(scope.event)"
     >
     <div class="var-picker-toggle">
       <button aria-label="Toggle Variable Picker" on:click="toggleBool(nameVarPickerVisible)" class="glyphicon-list-bullet"></button>

--- a/src/pages-tab/components/var-picker/var-picker.js
+++ b/src/pages-tab/components/var-picker/var-picker.js
@@ -46,5 +46,18 @@ export default Component.extend({
   tag: 'var-picker',
   view: template,
   leakScope: false,
-  ViewModel: VarPicker
+  ViewModel: VarPicker,
+  events: {
+    'ul button keydown': function (el, ev) {
+      const thisLi = ev.target.parentNode
+      const prevButton = thisLi.previousElementSibling && thisLi.previousElementSibling.querySelector('button')
+      const nextButton = thisLi.nextElementSibling && thisLi.nextElementSibling.querySelector('button')
+      ev.keyCode === 38 && prevButton && prevButton.focus() // up arrow key
+      ev.keyCode === 40 && nextButton && nextButton.focus() // down arrow key
+      if (({ 37: 1, 38: 1, 40: 1 })[ev.keyCode]) { // escape (37)
+        ev.preventDefault()
+        ev.stopPropagation()
+      }
+    }
+  }
 })

--- a/src/pages-tab/helpers/helpers.js
+++ b/src/pages-tab/helpers/helpers.js
@@ -1,6 +1,22 @@
 import DefineMap from 'can-define/map/map'
 import ckeArea from '~/src/utils/ckeditor-area'
 
+// shared with file-picker and var-picker-field, so the popover dropdown lists can only show one at a time across the app
+export const onlyOne = { observableBoolAtATime: undefined }
+// CCALI/a2jauthor#334
+document.addEventListener('focus', ev => {
+  // only try to close it if it's open
+  if (onlyOne.observableBoolAtATime && onlyOne.observableBoolAtATime.value) {
+    // ie doesn't have closest
+    if (ev && ev.target && ev.target.closest) {
+      // if focus moved outside of var picker field or file picker components...
+      if (!ev.target.closest('.auto-close-shared-bool-on-outside-focus')) {
+        onlyOne.observableBoolAtATime.value = false // auto close when focused elsewhere
+      }
+    }
+  }
+}, true)
+
 export const ckeFactory = (obj, key, label, placeholder) => ckeArea({
   label,
   placeholder: placeholder || '',


### PR DESCRIPTION
fixed buttons edit page button not appearing with newly created pages
fixed #333 - allow leading spaces for goto suggestions and validation
fixed #334 - auto close file and media dropdown menus
closes #338 - combine Page and Question info tabs
fixes #335 - arrow up and down to select var and file dropdown items
for #340 - use legacy varCreate so legacy varExists works in the legacy logic validation that's still used
fixes #331 - only add the safe merge step if necessary

paired with https://github.com/CCALI/a2jviewer/pull/229