### PR TITLE
375 safe uploads check

### DIFF
--- a/CAJA_WS.php
+++ b/CAJA_WS.php
@@ -1197,7 +1197,7 @@ function isExtensionAllowed($filename, $mediaOnly = false) {
 	if ($mediaOnly) {
 		$allowed = $media;
 	} else {
-		$allowed = array_merge($media, $other);
+		$allowed = $media ? array_merge($media, $other) : $other;
 	}
 
 	$testname = strtolower($filename);

--- a/CAJA_WS.php
+++ b/CAJA_WS.php
@@ -1193,12 +1193,25 @@ function isExtensionAllowed($filename, $mediaOnly = false) {
 
 	$media =  parse_ini_file($path . '/config_env.ini')['MEDIA_EXTS_ALLOWED'];
 	$other = parse_ini_file($path . '/config_env.ini')['EXTS_ALLOWED'];
-
-	if ($mediaOnly) {
-		$allowed = $media;
-	} else {
-		$allowed = $media ? array_merge($media, $other) : $other;
-	}
+    
+    // Test for valid entries in config file
+    // currently only tests if entries are arrays
+    // this could be expanded
+    if (!is_array($media)){
+        error_log("MEDIA_EXTS_ALLOWED in config_env.ini is empty");
+        fail_and_exit(500, 'bad configuration');
+    }
+    
+    if (!is_array($other)){
+        error_log("EXTS_ALLOWED in config_env.ini is empty");
+        fail_and_exit(500, 'bad configuration');
+    }
+ 
+    if ($mediaOnly) {
+		    $allowed = $media;
+    } else {
+	    $allowed = array_merge($media, $other);
+    }
 
 	$testname = strtolower($filename);
 

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1661258272762" cache-key="v" cache-version="1661258272762" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.js?v=1661258272762" cache-key="v" cache-version="1661258272762" main="a2jauthor/app"></script>
     </body>
   </html>


### PR DESCRIPTION
This PR handles any older config_env files that don't have allowed_media files set. Fixes the bug where a merge of a good list of file extensions was being merged with a `null` media_ext array, resulting in failed uploads even though all files were actually in the 'good' list.

closes #375 