### PR TITLE
Add fail on bad config

### DIFF
--- a/CAJA_WS.php
+++ b/CAJA_WS.php
@@ -1194,6 +1194,9 @@ function isExtensionAllowed($filename, $mediaOnly = false) {
 	$media =  parse_ini_file($path . '/config_env.ini')['MEDIA_EXTS_ALLOWED'];
 	$other = parse_ini_file($path . '/config_env.ini')['EXTS_ALLOWED'];
     
+    // Test for valid entries in config file
+    // currently only tests if entries are arrays
+    // this could be expanded
     if (!is_array($media)){
         error_log("MEDIA_EXTS_ALLOWED in config_env.ini is empty");
         fail_and_exit(500, 'bad configuration');
@@ -1208,6 +1211,7 @@ function isExtensionAllowed($filename, $mediaOnly = false) {
 		    $allowed = $media;
     } else {
 	    $allowed = array_merge($media, $other);
+    }
 
 	$testname = strtolower($filename);
 

--- a/CAJA_WS.php
+++ b/CAJA_WS.php
@@ -1193,12 +1193,21 @@ function isExtensionAllowed($filename, $mediaOnly = false) {
 
 	$media =  parse_ini_file($path . '/config_env.ini')['MEDIA_EXTS_ALLOWED'];
 	$other = parse_ini_file($path . '/config_env.ini')['EXTS_ALLOWED'];
-
-	if ($mediaOnly) {
-		$allowed = $media;
-	} else {
-		$allowed = $media ? array_merge($media, $other) : $other;
-	}
+    
+    if (!is_array($media)){
+        error_log("MEDIA_EXTS_ALLOWED in config_env.ini is empty");
+        fail_and_exit(500, 'bad configuration');
+    }
+    
+    if (!is_array($other)){
+        error_log("EXTS_ALLOWED in config_env.ini is empty");
+        fail_and_exit(500, 'bad configuration');
+    }
+ 
+    if ($mediaOnly) {
+		    $allowed = $media;
+    } else {
+	    $allowed = array_merge($media, $other);
 
 	$testname = strtolower($filename);
 


### PR DESCRIPTION
adds code to fails on bad MEDIA_EXTS_ALLOWED and EXTS_ALLOWED configs. Really just checks for presence of an array.