### PR TITLE
393 date bounds type restrict

### DIFF
--- a/index.dev.html
+++ b/index.dev.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708890758597" cache-key="v" cache-version="1708890758597" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708928958733" cache-key="v" cache-version="1708928958733" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.dev.html
+++ b/index.dev.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1707415201645" cache-key="v" cache-version="1707415201645" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708890758597" cache-key="v" cache-version="1708890758597" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.dev.html
+++ b/index.dev.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708929628150" cache-key="v" cache-version="1708929628150" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708953946048" cache-key="v" cache-version="1708953946048" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.dev.html
+++ b/index.dev.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708928958733" cache-key="v" cache-version="1708928958733" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708929284926" cache-key="v" cache-version="1708929284926" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.dev.html
+++ b/index.dev.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708929284926" cache-key="v" cache-version="1708929284926" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708929628150" cache-key="v" cache-version="1708929628150" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708929628150" cache-key="v" cache-version="1708929628150" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708953946048" cache-key="v" cache-version="1708953946048" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708953946048" cache-key="v" cache-version="1708953946048" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708984455616" cache-key="v" cache-version="1708984455616" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708929284926" cache-key="v" cache-version="1708929284926" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708929628150" cache-key="v" cache-version="1708929628150" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1708890948607" cache-key="v" cache-version="1708890948607" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708929284926" cache-key="v" cache-version="1708929284926" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,6 @@
         window.less = {async: true, fileSync: true};
       </script>
 
-      <script src=node_modules/steal/steal.production.js?v=1707416030358" cache-key="v" cache-version="1707416030358" main="a2jauthor/app"></script>
+      <script src=node_modules/steal/steal.production.js?v=1708890948607" cache-key="v" cache-version="1708890948607" main="a2jauthor/app"></script>
     </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "a2jauthor",
-  "version": "10.2.0-0",
+  "version": "10.2.0-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "a2jauthor",
-      "version": "10.2.0-0",
+      "version": "10.2.0-2",
       "license": "GNU AGPL v3.0",
       "dependencies": {
         "@caliorg/a2jdeps": "^7.1.7",
-        "@caliorg/a2jviewer": "^8.2.0-1",
+        "@caliorg/a2jviewer": "^8.2.0-10",
         "bit-tabs": "^2.0.0",
         "blueimp-file-upload": "^9.10.1",
         "bootstrap": "^3.4.1",
@@ -1181,9 +1181,9 @@
       }
     },
     "node_modules/@caliorg/a2jviewer": {
-      "version": "8.2.0-1",
-      "resolved": "https://registry.npmjs.org/@caliorg/a2jviewer/-/a2jviewer-8.2.0-1.tgz",
-      "integrity": "sha512-tp32ykS0qV5tzTPZums6ZSnLdZAU/XTmEGUcAyGxBxT+QY6FJzsiyRNTqD0KOH1JOezRhHM58apNzlg1b97d7A==",
+      "version": "8.2.0-10",
+      "resolved": "https://registry.npmjs.org/@caliorg/a2jviewer/-/a2jviewer-8.2.0-10.tgz",
+      "integrity": "sha512-DEOju3JWE9VWQu296NBA4rjoMVfJO3xoI+Mrpb8ohJenuer7cJ6oQCgPXvH3xF9bjMWPDemSp+gUJH7qSR8+cw==",
       "dependencies": {
         "@caliorg/a2jdeps": "^7.1.7",
         "bit-tabs": "^2.0.0",
@@ -14475,9 +14475,9 @@
       }
     },
     "@caliorg/a2jviewer": {
-      "version": "8.2.0-1",
-      "resolved": "https://registry.npmjs.org/@caliorg/a2jviewer/-/a2jviewer-8.2.0-1.tgz",
-      "integrity": "sha512-tp32ykS0qV5tzTPZums6ZSnLdZAU/XTmEGUcAyGxBxT+QY6FJzsiyRNTqD0KOH1JOezRhHM58apNzlg1b97d7A==",
+      "version": "8.2.0-10",
+      "resolved": "https://registry.npmjs.org/@caliorg/a2jviewer/-/a2jviewer-8.2.0-10.tgz",
+      "integrity": "sha512-DEOju3JWE9VWQu296NBA4rjoMVfJO3xoI+Mrpb8ohJenuer7cJ6oQCgPXvH3xF9bjMWPDemSp+gUJH7qSR8+cw==",
       "requires": {
         "@caliorg/a2jdeps": "^7.1.7",
         "bit-tabs": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2jauthor",
-  "version": "10.2.0-0",
+  "version": "10.2.0-2",
   "description": "A2J Authoring App GUI.",
   "license": "GNU AGPL v3.0",
   "author": {
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@caliorg/a2jdeps": "^7.1.7",
-    "@caliorg/a2jviewer": "^8.2.0-1",
+    "@caliorg/a2jviewer": "^8.2.0-10",
     "bit-tabs": "^2.0.0",
     "blueimp-file-upload": "^9.10.1",
     "bootstrap": "^3.4.1",

--- a/src/footer/footerVersion.js
+++ b/src/footer/footerVersion.js
@@ -1,7 +1,7 @@
 
 const version = {
   number: '10.2.0-0',
-  date: '2024-02-25'
+  date: '2024-02-26'
 }
 
 export default version

--- a/src/footer/footerVersion.js
+++ b/src/footer/footerVersion.js
@@ -1,6 +1,6 @@
 
 const version = {
-  number: '10.2.0-0',
+  number: '10.2.0-2',
   date: '2024-02-26'
 }
 

--- a/src/footer/footerVersion.js
+++ b/src/footer/footerVersion.js
@@ -1,7 +1,7 @@
 
 const version = {
   number: '10.2.0-0',
-  date: '2024-02-08'
+  date: '2024-02-25'
 }
 
 export default version

--- a/src/pages-tab/components/page-fields/page-fields.js
+++ b/src/pages-tab/components/page-fields/page-fields.js
@@ -222,12 +222,8 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
   parseDateBound(boundedDate){
     let textDate = "" // assume unfilled
 
-    console.log("YOYO" + boundedDate)
 
     if (boundedDate){
-      //if set assume it's today
-
-      //textDate = Date.toString()
 
       if (boundedDate !== "TODAY"){
         textDate =
@@ -238,9 +234,7 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
 
     }
 
-    console.log("DISCO" + textDate)
-
-    return textDate //Date.parse(textDate)
+    return textDate
 
   },
 
@@ -257,14 +251,9 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
     str =
       str.substr(4,2) + '/' +
       str.substr(6, 2) + '/' +
-      str.substr(0,4)
-      
-    console.log("BRUV: " + str)
-      
+      str.substr(0,4)      
 
     str = str.match(new RegExp(el.pattern || '.', 'g')).join('')
-
-    console.log("MANG: " + str)
 
    return str
 

--- a/src/pages-tab/components/page-fields/page-fields.js
+++ b/src/pages-tab/components/page-fields/page-fields.js
@@ -212,6 +212,67 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
     return el.value
   },
 
+  setBound(el){
+  },
+
+  checktoToday(el){
+    return el.checked ? "TODAY": ""
+  },
+
+  parseDateBound(boundedDate){
+    let textDate = "" // assume unfilled
+
+    console.log("YOYO" + boundedDate)
+
+    if (boundedDate){
+      //if set assume it's today
+
+      //textDate = Date.toString()
+
+      if (boundedDate !== "TODAY"){
+        if (boundedDate.length == 8) {
+          textDate =
+          boundedDate.substr(0,4) + '-' +
+          boundedDate.substr(4, 2) + '-' +
+          boundedDate.substr(6, 2)
+
+        } else if (boundedDate.length == 6 ){
+          textDate =
+          boundedDate.substr(0,2) + '-' +
+          boundedDate.substr(2, 2) + '-' +
+          boundedDate.substr(4, 2)
+
+        }
+        
+      }
+
+    }
+
+    console.log("DISCO" + textDate)
+
+    return textDate //Date.parse(textDate)
+
+  },
+
+  toggleDateBoundEnable(el){
+    $(el).prop('disabled', !$(el).prop('disabled'))
+  },
+
+  mangleDateBound(el){
+
+    let str = 
+      el.value.substr(0,2) + '/' +
+      el.value.substr(2, 2) + '/' +
+      el.value.substr(4)
+
+    str = str.match(new RegExp(el.pattern || '.', 'g')).join('')
+
+    console.log("MANG: " + str)
+
+   return str
+
+  },
+
   applyPattern (el) {
     el.value = el.value.match(new RegExp(el.pattern || '.', 'g')).join('')
     return el.value

--- a/src/pages-tab/components/page-fields/page-fields.js
+++ b/src/pages-tab/components/page-fields/page-fields.js
@@ -230,20 +230,10 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
       //textDate = Date.toString()
 
       if (boundedDate !== "TODAY"){
-        if (boundedDate.length == 8) {
-          textDate =
-          boundedDate.substr(0,4) + '-' +
-          boundedDate.substr(4, 2) + '-' +
-          boundedDate.substr(6, 2)
-
-        } else if (boundedDate.length == 6 ){
-          textDate =
-          boundedDate.substr(0,2) + '-' +
-          boundedDate.substr(2, 2) + '-' +
-          boundedDate.substr(4, 2)
-
-        }
-        
+        textDate =
+        boundedDate.substr(4) + '-' +
+        boundedDate.substr(2, 2) + '-' +
+        boundedDate.substr(0,2)
       }
 
     }
@@ -260,10 +250,17 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
 
   mangleDateBound(el){
 
-    let str = 
-      el.value.substr(0,2) + '/' +
-      el.value.substr(2, 2) + '/' +
-      el.value.substr(4)
+    let str = el.value.split(',').join('')
+    str = str.split('-').join('')
+    console.log("JAWN: " + str)
+
+    str =
+      str.substr(4,2) + '/' +
+      str.substr(6, 2) + '/' +
+      str.substr(0,4)
+      
+    console.log("BRUV: " + str)
+      
 
     str = str.match(new RegExp(el.pattern || '.', 'g')).join('')
 

--- a/src/pages-tab/components/page-fields/page-fields.js
+++ b/src/pages-tab/components/page-fields/page-fields.js
@@ -232,8 +232,8 @@ export const PageFieldsVM = DefineMap.extend('PageFieldsVM', {
       if (boundedDate !== "TODAY"){
         textDate =
         boundedDate.substr(4) + '-' +
-        boundedDate.substr(2, 2) + '-' +
-        boundedDate.substr(0,2)
+        boundedDate.substr(0, 2) + '-' +
+        boundedDate.substr(2,2)
       }
 
     }

--- a/src/pages-tab/components/page-fields/page-fields.stache
+++ b/src/pages-tab/components/page-fields/page-fields.stache
@@ -125,6 +125,7 @@
                     </div>
                   </div>
                 </div>
+                <div>
                   <label class="control-label">Max Value:</label>
                   <input class="form-control ui-widget editable" 
                     type="date" placeholder="max"

--- a/src/pages-tab/components/page-fields/page-fields.stache
+++ b/src/pages-tab/components/page-fields/page-fields.stache
@@ -106,6 +106,17 @@
                     value:bind="field.field.min"
                     pattern="TODAY|(?:^-(?=.*\d))|\d*"
                     on:blur="field.field.min = applyPattern(scope.element)"
+                    hidden
+                  >
+                  <input class="form-control ui-widget editable" type="date" placeholder="min"
+                    value:bind="field.field.minDate"
+                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
+                    on:blur="field.field.min = applyPattern(scope.element)"
+                  >
+                  <input class="form-control ui-widget editable" type="checkbox" placeholder="min"
+                    value:bind="field.field.min"
+                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
+                    on:blur="field.field.min = applyPattern(scope.element)"
                   >
                 </div>
                 <div class="editspan form-group" name="max">
@@ -114,6 +125,17 @@
                     value:bind="field.field.max"
                     pattern="TODAY|(?:^-(?=.*\d))|\d*"
                     on:blur="field.field.max = applyPattern(scope.element)"
+                    hidden
+                  >
+                  <input class="form-control ui-widget editable" type="date" placeholder="min"
+                    value:bind="field.field.maxDate"
+                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
+                    on:blur="field.field.min = applyPattern(field.field.maxDate)"
+                  >
+                  <input class="form-control ui-widget editable" type="checkbox" placeholder="min"
+                    value:bind="field.field.max"
+                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
+                    on:blur="field.field.min = applyPattern(scope.element)"
                   >
                 </div>
               {{/if}}

--- a/src/pages-tab/components/page-fields/page-fields.stache
+++ b/src/pages-tab/components/page-fields/page-fields.stache
@@ -101,42 +101,50 @@
               </div>
               {{#if(field.canMinMax)}}
                 <div class="editspan form-group" name="min">
+
                   <label class="control-label">Min Value:</label>
-                  <input class="form-control ui-widget editable" type="text" placeholder="min"
-                    value:bind="field.field.min"
+                  <input class="form-control ui-widget editable" 
+                    type="date" placeholder="min" 
+                    id="min-date"
                     pattern="TODAY|(?:^-(?=.*\d))|\d*"
-                    on:blur="field.field.min = applyPattern(scope.element)"
-                    hidden
+                    value="{{parseDateBound(field.field.min)}}"
+                    on:blur="field.field.min = mangleDateBound(scope.element)"
+                    {{ #eq(field.field.min, "TODAY")}} disabled {{/eq}}
                   >
-                  <input class="form-control ui-widget editable" type="date" placeholder="min"
-                    value:bind="field.field.minDate"
-                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
-                    on:blur="field.field.min = applyPattern(scope.element)"
-                  >
-                  <input class="form-control ui-widget editable" type="checkbox" placeholder="min"
-                    value:bind="field.field.min"
-                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
-                    on:blur="field.field.min = applyPattern(scope.element)"
-                  >
+
+                  <div name="today-min" class="{{^if(field.canRequire)}}hidden{{/if}}">
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox" 
+                          {{ #eq(field.field.min, "TODAY")}} checked {{/eq}}
+                          on:blur="field.field.min = checktoToday(scope.element)"
+                          on:click="toggleDateBoundEnable('#min-date')"
+                          value:bind="field.field.min"
+                          value="TODAY"> TODAY
+                      </label>
+                    </div>
+                  </div>
                 </div>
-                <div class="editspan form-group" name="max">
                   <label class="control-label">Max Value:</label>
-                  <input class="form-control ui-widget editable" type="text" placeholder="max"
-                    value:bind="field.field.max"
+                  <input class="form-control ui-widget editable" 
+                    type="date" placeholder="max"
+                    id="max-date"
+                    value="{{parseDateBound(field.field.max)}}"
                     pattern="TODAY|(?:^-(?=.*\d))|\d*"
-                    on:blur="field.field.max = applyPattern(scope.element)"
-                    hidden
+                    {{ #eq(field.field.max, "TODAY")}} disabled {{/eq}}
+                    on:blur="field.field.max = mangleDateBound(scope.element)"
                   >
-                  <input class="form-control ui-widget editable" type="date" placeholder="min"
-                    value:bind="field.field.maxDate"
-                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
-                    on:blur="field.field.min = applyPattern(field.field.maxDate)"
-                  >
-                  <input class="form-control ui-widget editable" type="checkbox" placeholder="min"
-                    value:bind="field.field.max"
-                    pattern="TODAY|(?:^-(?=.*\d))|\d*"
-                    on:blur="field.field.min = applyPattern(scope.element)"
-                  >
+                  <div name="today-max" class="{{^if(field.canRequire)}}hidden{{/if}}">
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox"
+                          {{ #eq(field.field.max, "TODAY")}} checked {{/eq}}
+                          on:blur="field.field.max = TODAY"
+                          on:click="toggleDateBoundEnable('#max-date')"
+                          value="TODAY"> TODAY
+                      </label>
+                    </div>
+                  </div>
                 </div>
               {{/if}}
               {{#if(field.canList)}}


### PR DESCRIPTION
fix #393 

restricts UI so user cannot enter bad date boundaries in author. Shows dates in either a checkbox for TODAY or html date input to be less ambiguous and easier to use

Old
![current-today-author](https://github.com/CCALI/a2jauthor/assets/23437466/d81252f6-e6b3-4afb-a620-1ee85f6c6404)

NEW
![NEW-today-type-restrict-author](https://github.com/CCALI/a2jauthor/assets/23437466/bcf08e42-fc59-4bc8-82f0-15c557899ad8)
